### PR TITLE
Chore: Import updated workflow and linting from actions-template

### DIFF
--- a/.github/workflows/release-drafter.yaml
+++ b/.github/workflows/release-drafter.yaml
@@ -9,7 +9,6 @@ on:
   push:
     branches:
       - main
-      - master
   # pull_request is required for autolabeler
   pull_request:
     types:
@@ -29,26 +28,9 @@ concurrency:
   # yamllint disable-line rule:line-length
   group: "rd-${{ github.event_name }}-${{ github.event.number }}-${{ github.ref }}"
   cancel-in-progress: true
+  # yamllint enable rule:line-length
 
 jobs:
-  show_concurrency_group:
-    name: 'Concurrency Group'
-    runs-on: 'ubuntu-latest'
-    timeout-minutes: 2
-    steps:
-      - name: 'Concurrency Group'
-        shell: bash
-        # yamllint disable rule:line-length
-        run: |
-          # Concurrency Group
-          echo "Concurrency group: rd-${{ github.event_name }}-${{ github.event.number }}-${{ github.ref }}"
-          # shellcheck disable=SC2129
-          echo "## Release Drafter" \
-            >> "$GITHUB_STEP_SUMMARY"
-          echo "Concurrency group: rd-${{ github.event_name }}-${{ github.event.number }}-${{ github.ref }}" \
-            >> "$GITHUB_STEP_SUMMARY"
-
-  # yamllint enable rule:line-length
   update_release_draft:
     name: 'Update Release Draft'
     permissions:
@@ -58,14 +40,25 @@ jobs:
       pull-requests: write
     runs-on: 'ubuntu-latest'
     timeout-minutes: 3
+    # yamllint disable rule:line-length
     steps:
       # Harden the runner used by this workflow
-      # yamllint disable-line rule:line-length
       - uses: step-security/harden-runner@ec9f2d5744a09debf3a187a3f4f675c53b671911 # v2.13.0
         with:
           egress-policy: 'audit'
 
-      # yamllint disable-line rule:line-length
-      - uses: release-drafter/release-drafter@b1476f6e6eb133afa41ed8589daba6dc69b4d3f5 # v6.1.0
+      - name: 'Show concurrency group'
+        shell: bash
+        # yamllint disable rule:line-length
+        run: |
+          # Show concurrency group
+          {
+            echo '## Release Drafter'
+            echo "Concurrency group: rd-${{ github.event_name }}-${{ github.event.number }}-${{ github.ref }}"
+          } >> "GITHUB_SUMMARY_STEP"
+          echo "Concurrency group: rd-${{ github.event_name }}-${{ github.event.number }}-${{ github.ref }}"
+
+      - name: 'Update draft release'
+        uses: release-drafter/release-drafter@b1476f6e6eb133afa41ed8589daba6dc69b4d3f5 # v6.1.0
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,14 @@
 # SPDX-FileCopyrightText: 2025 The Linux Foundation
 
 ci:
-  autofix_commit_msg: "Chore: pre-commit autoupdate"
+  autofix_commit_msg: |
+    Chore: pre-commit autofixes
+
+    Signed-off-by: pre-commit-ci[bot] <pre-commit-ci@users.noreply.github.com>
+  autoupdate_commit_msg: |
+    Chore: pre-commit autoupdate
+
+    Signed-off-by: pre-commit-ci[bot] <pre-commit-ci@users.noreply.github.com>
 
 exclude: "^docs/conf.py"
 
@@ -43,7 +50,7 @@ repos:
         types: [yaml]
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: 73b0f6d59bbfcb75e17a4653d581c9dfaca13969  # frozen: v0.12.5
+    rev: 4cbc74d53fe5634e58e0e65db7d28939c9cec3f7  # frozen: v0.12.7
     hooks:
       - id: ruff
         files: ^(scripts|tests|custom_components)/.+\.py$
@@ -52,7 +59,7 @@ repos:
         files: ^(scripts|tests|custom_components)/.+\.py$
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: 850d8bf806620ef89a99381c5cf5ea2c1ea826dd  # frozen: v1.17.0
+    rev: 412de98d50e846f31ea6f4b0ad036f2c24a7a024  # frozen: v1.17.1
     hooks:
       - id: mypy
 
@@ -90,3 +97,18 @@ repos:
     rev: 63c8f8312b7559622c0d82815639671ae42132ac # frozen: v2.4.1
     hooks:
       - id: codespell
+
+  - repo: https://github.com/python-jsonschema/check-jsonschema
+    rev: 54da05914997e6b04e4db33ed6757d744984c68b  # frozen: 0.33.2
+    hooks:
+      - id: check-github-actions
+      - id: check-github-workflows
+      - id: check-jsonschema
+        name: Check GitHub Workflows set timeout-minutes
+        args:
+          - --builtin-schema
+          - github-workflows-require-timeout
+        files: ^\.github/workflows/[^/]+$
+        types:
+          - yaml
+      - id: check-readthedocs

--- a/action.yaml
+++ b/action.yaml
@@ -11,26 +11,21 @@ inputs:
   url:
     description: 'URL to download'
     required: true
-    # type: 'string'
   # Optional
   exit_on_fail:
     description: 'Exit with error if download fails'
     required: false
-    # type: 'boolean'
-    default: true
+    default: 'true'
   no_clobber:
     description: 'Will not overwrite existing local file'
     required: false
-    # type: 'boolean'
-    default: false
+    default: 'false'
   path:
     description: 'Save file to this local file system path'
     required: false
-    # type: 'string'
   wget_flags:
     description: 'Additional/supplmentary flags to wget command'
     required: false
-    # type: 'string'
     default: '-q'
 
 runs:


### PR DESCRIPTION
This PR imports the updated pre-commit configuration and release-drafter workflow from the actions-template repository to ensure linting checks pass correctly.

Changes include:
- Updated `.pre-commit-config.yaml` with latest linting tool versions and additional validation hooks
- Updated `.github/workflows/release-drafter.yaml` with timeout-minutes fix for workflow validation
- Updated commit message format with signed-off-by lines
- Additional JSON schema validation for GitHub Actions/Workflows

This ensures consistency across all repositories in the lfreleng-actions organization and fixes workflow validation issues.