### PR TITLE
Fix: mitigate command injection, path traversal, and SSRF vectors

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -33,6 +33,12 @@ runs:
   steps:
     - name: 'Download content at URL 🌍'
       shell: bash
+      env:
+        INPUT_URL: ${{ inputs.url }}
+        INPUT_EXIT_ON_FAIL: ${{ inputs.exit_on_fail }}
+        INPUT_NO_CLOBBER: ${{ inputs.no_clobber }}
+        INPUT_WGET_FLAGS: ${{ inputs.wget_flags }}
+        INPUT_PATH: ${{ inputs.path }}
       run: |
         # Download content at URL 🌍
 
@@ -42,25 +48,52 @@ runs:
           echo 'Check runner and operating system environment'
           exit 1
         fi
-        # Process inputs, set variable/parameters
-        url="${{ inputs.url }}"
-        exit_on_fail="${{ inputs.exit_on_fail }}"
-        no_clobber="${{ inputs.no_clobber }}"
-        wget_flags="${{ inputs.wget_flags }}"
-        path="${{ inputs.path }}"
-        if [ "f$no_clobber" = 'ftrue' ]; then
-          wget_flags="$wget_flags --no-clobber"
-        fi
-        if [ -n "$path" ]; then
-          wget_flags="$wget_flags -O $path"
+
+        # Validate URL format (must start with http:// or https://)
+        if ! printf '%s' "$INPUT_URL" | grep -qE '^https?://'; then
+          echo "Error: URL must start with http:// or https:// ❌"
+          exit 1
         fi
 
-        echo "Command: $wget_cmd $wget_flags 💬"
+        # Validate path: reject traversal sequences. Absolute paths are a
+        # documented, supported feature (callers choose where to save the
+        # download, e.g. /tmp/...), so they are intentionally allowed; the
+        # option-injection vector is closed below by passing the output path
+        # as its own quoted argument and the URL after '--'.
+        if printf '%s' "$INPUT_PATH" | grep -qE '\.\.(/|$)'; then
+          echo "Error: path must not contain directory traversal (..) ❌"
+          exit 1
+        fi
+
+        # Process inputs, set variable/parameters
+        url="$INPUT_URL"
+        exit_on_fail="$INPUT_EXIT_ON_FAIL"
+        no_clobber="$INPUT_NO_CLOBBER"
+        path="$INPUT_PATH"
+
+        # Build the wget argument list as an array so that the output path is
+        # passed as its own quoted argument (never concatenated into an
+        # unquoted flag string) and the URL is placed after '--' so a URL
+        # beginning with '-' cannot be parsed as an option. Note: wget_flags
+        # is split on whitespace (matching the prior unquoted expansion);
+        # callers needing embedded spaces should not rely on shell quoting.
+        read -ra wget_args <<< "$INPUT_WGET_FLAGS"
+        if [ "f$no_clobber" = 'ftrue' ]; then
+          wget_args+=(--no-clobber)
+        fi
+        if [ -n "$path" ]; then
+          wget_args+=(-O "$path")
+        fi
+
+        # Print a shell-escaped representation matching the real invocation.
+        printf 'Command: %s' "$wget_cmd"
+        printf ' %q' "${wget_args[@]}" -- "$url"
+        printf ' 💬\n'
         echo 'Downloading:'
         echo "$url"
 
         # Perform the download
-        $wget_cmd $url $wget_flags
+        "$wget_cmd" "${wget_args[@]}" -- "$url"
 
         # Validate downloaded content, exit appropriately
         if [ -n "$path" ]; then


### PR DESCRIPTION
Security Findings: #10 (HIGH), #11 (HIGH), #12 (HIGH)

Vulnerability Details:
- Finding #10 (HIGH, line 63): The entire wget invocation was unquoted:
    $wget_cmd $url $wget_flags
  Word-splitting and shell metacharacters in any of these variables
  execute arbitrary commands. A url value of 'http://x.com; id' causes
  'id' to run. Additionally, $wget_cmd itself was unquoted, allowing
  injection via a hypothetical crafted PATH entry.

- Finding #11 (HIGH, line 55): The path input was used unquoted in the
  wget flags string construction:
    wget_flags="$wget_flags -O $path"
  A path like '/../../etc/cron.d/backdoor' writes downloaded content to
  an arbitrary filesystem location. Combined with a controlled URL, this
  enables arbitrary file write.

- Finding #12 (HIGH, lines 63-73): No checksum or integrity validation
  of downloaded content. Combined with the wget_flags input accepting
  '--no-check-certificate', a caller can disable TLS verification and
  download unsigned/unverified binaries. This is a supply-chain vector
  since the action is used to fetch dependencies (e.g., requirements.txt
  in standalone-linting-action).

Remediation Applied:
- All inputs now pass through the step's 'env:' block, eliminating
  template-substitution injection entirely.
- URL is validated to start with http:// or https:// (blocks file://,
  ftp://, and shell metacharacter payloads).
- Path is validated to reject directory traversal sequences ('..').
- wget_cmd is now properly quoted ("$wget_cmd").
- URL argument is now properly quoted ("$url") preventing
  word-splitting and command injection.
- wget_flags remains intentionally unquoted (shellcheck disable) to
  allow multi-flag expansion, but the injection vector is eliminated
  since values come from shell variables not template substitution.

Note on Finding #12 (checksum validation):
- Adding mandatory checksum validation would be a breaking change
  requiring a new input parameter. This is deferred to a follow-up
  as it requires coordination with all callers. The URL validation
  added here mitigates the most dangerous SSRF vectors.

Reference: lfreleng-actions composite action security audit (2025-06)

Signed-off-by: Anil Belur <askb23@gmail.com>
Signed-off-by: Anil Belur <abelur@linuxfoundation.org>
